### PR TITLE
Call health check before sending data to Open Podcast API

### DIFF
--- a/apple/main.py
+++ b/apple/main.py
@@ -1,6 +1,7 @@
 import os
 import datetime as dt
 import json
+import time
 from loguru import logger
 from appleconnector import AppleConnector
 import requests
@@ -37,6 +38,13 @@ class OpenPodcastApi:
             "data": data,
         }
         return requests.post(self.endpoint, headers=headers, json=json)
+
+    def health(self):
+        """
+        Send GET request to the Open Podcast healthcheck endpoint `/health`.
+        """
+        headers = {"Authorization": f"Bearer {self.token}"}
+        return requests.get(f"{self.endpoint}/health", headers=headers)
 
 
 def get_cookies():
@@ -98,6 +106,18 @@ def fetch_and_capture(
 
     return data
 
+def api_healthcheck(open_podcast_client):
+    """
+    Try three times to get 200 from healthcheck endpoint
+    """
+    for i in range(3):
+        status = open_podcast_client.health()
+        if status.status_code == 200:
+            return True
+        else:
+            logger.info(f"Healthcheck failed, retrying in 5 seconds...")
+            time.sleep(5)
+    return False
 
 def main():
     # Call API which returns an array of cookies.
@@ -110,7 +130,6 @@ def main():
     #   },
     #   ...
     # ]
-
     cookies = get_cookies()
 
     # Get myacinfo cookie
@@ -132,6 +151,11 @@ def main():
         endpoint=OPENPODCAST_API_ENDPOINT,
         token=OPENPODCAST_API_TOKEN,
     )
+
+    # Check if API is up before sending data
+    if not api_healthcheck(open_podcast_client):
+        logger.error("Open Podcast API is not up. Quitting")
+        return
 
     start = dt.datetime.now() - dt.timedelta(days=1)
     end = dt.datetime.now()

--- a/apple/main.py
+++ b/apple/main.py
@@ -106,6 +106,7 @@ def fetch_and_capture(
 
     return data
 
+
 def api_healthcheck(open_podcast_client):
     """
     Try three times to get 200 from healthcheck endpoint
@@ -118,6 +119,7 @@ def api_healthcheck(open_podcast_client):
             logger.info(f"Healthcheck failed, retrying in 5 seconds...")
             time.sleep(5)
     return False
+
 
 def main():
     # Call API which returns an array of cookies.


### PR DESCRIPTION
Since the API runs on Google cloud run at the moment
and can scale down to 0 instances if not needed,
there can be a delay in the availability of the service
in a cold-start scenario. To avoid errors, we wait until
the health check responds with a `200` status code
before we continue.