### PR TITLE
Env-files

### DIFF
--- a/apple/main.py
+++ b/apple/main.py
@@ -9,11 +9,38 @@ import requests
 import types
 import itertools
 
-PODCAST_ID = os.environ.get("PODCAST_ID")
-OPENPODCAST_API_ENDPOINT = os.environ.get("OPENPODCAST_API_ENDPOINT")
-OPENPODCAST_API_TOKEN = os.environ.get("OPENPODCAST_API_TOKEN")
+
+def load_file_or_env(var, default=None):
+    """
+    Load environment variable from file or string
+    """
+    env_file = f"{var}_FILE"
+    if os.path.isfile(env_file):
+        with open(env_file, "r") as f:
+            return f.read().strip()
+    else:
+        return os.environ.get(var, default)
+
+
+def test_load_file_or_env():
+    os.environ["TEST_VAR"] = "test"
+    assert load_file_or_env("TEST_VAR") == "test"
+    assert load_file_or_env("TEST_VAR", "default") == "test"
+    assert load_file_or_env("TEST_VAR2", "default") == "default"
+    with open("TEST_VAR2_FILE", "w") as f:
+        f.write("test2")
+    assert load_file_or_env("TEST_VAR2", "default") == "test2"
+
+
 APPLE_AUTOMATION_ENDPOINT = "https://apple-automation.openpodcast.dev/cookies"
-APPLE_AUTOMATION_BEARER_TOKEN = os.environ.get("APPLE_AUTOMATION_BEARER_TOKEN")
+
+OPENPODCAST_API_TOKEN = load_file_or_env("OPENPODCAST_API_TOKEN")
+APPLE_AUTOMATION_BEARER_TOKEN = load_file_or_env("APPLE_AUTOMATION_BEARER_TOKEN")
+
+PODCAST_ID = os.environ.get("PODCAST_ID")
+OPENPODCAST_API_ENDPOINT = os.environ.get(
+    "OPENPODCAST_API_ENDPOINT", "https://api.openpodcast.dev"
+)
 
 # Store data locally for debugging. If this is set to `False`,
 # data will only be sent to Open Podcast API.

--- a/spotify/main.py
+++ b/spotify/main.py
@@ -8,14 +8,27 @@ from spotifyconnector import SpotifyConnector
 import requests
 import types
 
+def load_file_or_env(var, default=None):
+    """
+    Load environment variable from file or string
+    """
+    env_file = f"{var}_FILE"
+    if os.path.isfile(env_file):
+        with open(env_file, "r") as f:
+            return f.read().strip()
+    else:
+        return os.environ.get(var, default)
+
 BASE_URL = "https://generic.wg.spotify.com/podcasters/v0"
 CLIENT_ID = "05a1371ee5194c27860b3ff3ff3979d2"
+
+SP_DC = load_file_or_env("SPOTIFY_SP_DC")
+SP_KEY = load_file_or_env("SPOTIFY_SP_KEY")
+OPENPODCAST_API_TOKEN = load_file_or_env("OPENPODCAST_API_TOKEN")
+
 SPOTIFY_PODCAST_ID = os.environ.get("SPOTIFY_PODCAST_ID")
-SP_DC = os.environ.get("SPOTIFY_SP_DC")
-SP_KEY = os.environ.get("SPOTIFY_SP_KEY")
 FEED_URL = "https://feeds.redcircle.com/2c2cd740-1c1f-4928-adac-98a692dbf4c2"
-OPENPODCAST_API_ENDPOINT = os.environ.get("OPENPODCAST_API_ENDPOINT")
-OPENPODCAST_API_TOKEN = os.environ.get("OPENPODCAST_API_TOKEN")
+OPENPODCAST_API_ENDPOINT = os.environ.get("OPENPODCAST_API_ENDPOINT", "https://api.openpodcast.dev")
 
 # Store data locally for debugging. If this is set to `False`,
 # data will only be sent to Open Podcast API.


### PR DESCRIPTION
Fixes #19.

Here are the changes (which don't fully align with the issue ticket):

Spotify:

* `PH_PROJECT_API_KEY` is obsolete and was removed.
* Added `OPENPODCAST_API_TOKEN_FILE` support.
* Set https://api.openpodcast.dev as default for `OPENPODCAST_API_ENDPOINT`.

Apple:

* `APPLE_AUTOMATION_ENDPOINT_FILE`: Guess this has become obsolete with the latest introduction of API bearer tokens for different podcasts (see next point).
* Added support for `APPLE_AUTOMATION_BEARER_TOKEN_FILE`
* Added support for `OPENPODCAST_API_TOKEN_FILE`

I don't like the fact that the `load_file_or_env()` function is duplicated, but changing that would require a bigger refactor into (sub-)modules. We should do that as a separate step in my opinion.
Same for adding tests: it would require refactoring to run them. For now I've just added an example test. 😕 