### PR TITLE
Bump spotifygraphqlconnector to 0.5.0

### DIFF
--- a/anchor/job/__main__.py
+++ b/anchor/job/__main__.py
@@ -61,11 +61,7 @@ PODCAST_ID = load_file_or_env("PODCAST_ID", "")
 if not SPOTIFY_SHOW_URI and PODCAST_ID.startswith("spotify:show:"):
     SPOTIFY_SHOW_URI = PODCAST_ID
 
-# Optional: legacy station ID – only needed if get_all_episodes is called
-# without a show URI.  Can also be supplied as PODCAST_ID when numeric.
-SPOTIFY_STATION_ID = load_file_or_env("SPOTIFY_STATION_ID", "")
-if not SPOTIFY_STATION_ID and PODCAST_ID.isdigit():
-    SPOTIFY_STATION_ID = PODCAST_ID
+
 
 # Date range used for analytics queries.
 START_DATE_STR = load_env(
@@ -104,11 +100,14 @@ print("Done initializing environment")
 # Connectors
 # ---------------------------------------------------------------------------
 
+# Note: as of spotifygraphqlconnector 0.5.0 the GraphQL API keys the episode
+# list by ``showUri`` (Spotify migrated ``WebGetIndexedEpisodeList`` away from
+# ``stationId`` in April 2026), so ``SPOTIFY_STATION_ID`` is no longer needed
+# and the connector ignores it.
 connector = SpotifyGraphQLConnector(
     sp_dc=SPOTIFY_SP_DC,
     sp_key=SPOTIFY_SP_KEY,
     show_uri=SPOTIFY_SHOW_URI or None,
-    station_id=SPOTIFY_STATION_ID or None,
 )
 
 # Resolve the show URI once so every subsequent call can reuse it.

--- a/anchor/requirements.txt
+++ b/anchor/requirements.txt
@@ -1,4 +1,4 @@
-spotifygraphqlconnector==0.3.0
+spotifygraphqlconnector==0.5.0
 certifi==2024.2.2
 charset-normalizer==3.1.0
 idna==3.4

--- a/connector_manager/requirements.txt
+++ b/connector_manager/requirements.txt
@@ -1,7 +1,7 @@
 mysql_connector_python==8.0.33
 python_gnupg==0.5.0
 appleconnector==0.4.0
-spotifygraphqlconnector==0.3.0
+spotifygraphqlconnector==0.5.0
 spotifyconnector==0.8.2
 podigeeconnector==0.3.0
 autopep8==1.7.0


### PR DESCRIPTION
Spotify migrated `WebGetIndexedEpisodeList` from `stationId` to `showUri` in April 2026. spotifygraphqlconnector 0.5.0 picks up the new persisted-query hash and:

- Keys `get_episode_list` / `get_all_episodes` by `show_uri` instead of `station_id` (`station_id` is now deprecated and ignored).
- Falls back to the new `data.show.episodesV2` response shape (with the legacy `data.showByStationId` shape kept as a fallback).
- Logs the GraphQL payload + response on non-retried HTTP errors, making real-world failures much easier to debug.
- Raises a clearer error when `stationId` resolution unexpectedly fails on a show.

### Changes here

- Bump `spotifygraphqlconnector` from 0.3.0 → 0.5.0 in both `anchor/requirements.txt` and `connector_manager/requirements.txt`.
- Drop the `SPOTIFY_STATION_ID` env-var plumbing from `anchor/job/__main__.py` — the underlying API no longer uses it, and the connector auto-resolves the show URI from the account when not provided.

The legacy-shape `legacy_web_station_id` derived from the per-episode metadata payload (used by `wrap_episode_metadata` to populate `podcastId` in the Anchor-compatible output) is unaffected.