### PR TITLE
chore(deps): bump spotifygraphqlconnector to 0.5.1

### DIFF
--- a/anchor/requirements.txt
+++ b/anchor/requirements.txt
@@ -1,4 +1,4 @@
-spotifygraphqlconnector==0.5.0
+spotifygraphqlconnector==0.5.1
 certifi==2024.2.2
 charset-normalizer==3.1.0
 idna==3.4

--- a/connector_manager/requirements.txt
+++ b/connector_manager/requirements.txt
@@ -1,7 +1,7 @@
 mysql_connector_python==8.0.33
 python_gnupg==0.5.0
 appleconnector==0.4.0
-spotifygraphqlconnector==0.5.0
+spotifygraphqlconnector==0.5.1
 spotifyconnector==0.8.2
 podigeeconnector==0.3.0
 autopep8==1.7.0


### PR DESCRIPTION
Bumps `spotifygraphqlconnector` from 0.5.0 to 0.5.1 in `anchor/requirements.txt` and `connector_manager/requirements.txt`.

## Upstream changes (0.5.0 → 0.5.1)

Two backward-compatible behaviour tweaks; no public API changes:

1. `get_episode_list()` / `get_all_episodes()` now read the response from `data.showByShowUri.episodesV2` first, with `data.show` and `data.showByStationId` retained as fallbacks. Our caller already passes `show_uri` (or relies on auto-resolution), so no code change needed.
2. `get_show_audience_discovery()` no longer forwards `WINDOW_CUSTOM` to the upstream API (which would error on `audienceSize`/`impressionsFunnel`). When `start_date`/`end_date` are supplied the connector now maps the span to the nearest predefined window (`WINDOW_LAST_SEVEN_DAYS` / `THIRTY` / `NINETY`). Our anchor pipeline calls it with a custom range so this swap happens transparently.

Method signatures, return shapes and the constructor are unchanged, so no callsite updates were required.