### PR TITLE
chore(deps): bump spotifygraphqlconnector to 0.5.2

### DIFF
--- a/anchor/requirements.txt
+++ b/anchor/requirements.txt
@@ -1,4 +1,4 @@
-spotifygraphqlconnector==0.5.1
+spotifygraphqlconnector==0.5.2
 certifi==2024.2.2
 charset-normalizer==3.1.0
 idna==3.4

--- a/connector_manager/requirements.txt
+++ b/connector_manager/requirements.txt
@@ -1,7 +1,7 @@
 mysql_connector_python==8.0.33
 python_gnupg==0.5.0
 appleconnector==0.4.0
-spotifygraphqlconnector==0.5.1
+spotifygraphqlconnector==0.5.2
 spotifyconnector==0.8.2
 podigeeconnector==0.3.0
 autopep8==1.7.0


### PR DESCRIPTION
Patch bump for [`spotifygraphqlconnector`](https://pypi.org/project/spotifygraphqlconnector/) from `0.5.1` → `0.5.2`.

## Changes

- **`anchor/requirements.txt`** — bump pin used by the anchor pipeline (the only direct consumer of this connector).
- **`connector_manager/requirements.txt`** — bump pin in the production runtime image so `print_debug_output()` reports the new version and the bundled connector matches what gets shelled out to.

## Notes

- `0.5.2` is a small patch release; no API surface changes affecting our usage in [`anchor/job/__main__.py`](../blob/main/anchor/job/__main__.py).
- Upstream still declares `requires-python = ">=3.11"`, which matches our `python:3.11-slim-bullseye` base image.
- Independent of the apple uv-migration PR (#131); these can land in either order.