### PR TITLE
Bump spotifyconnector 0.8.2 -> 0.8.3

### DIFF
--- a/spotify/requirements.txt
+++ b/spotify/requirements.txt
@@ -10,7 +10,7 @@ python-dateutil==2.8.2
 PyYAML==6.0.3
 requests==2.32.5
 six==1.16.0
-spotifyconnector==0.8.2
+spotifyconnector==0.8.3
 tenacity==9.1.4
 toml==0.10.2
 urllib3==1.26.15


### PR DESCRIPTION
Picks up the [uv migration release](https://github.com/openpodcast/spotify-connector/releases/tag/v0.8.3) of `spotify-connector`.

No behavioural changes; the only consumer-visible difference is that `myst-parser` is now an optional `[docs]` extra instead of a hard runtime dependency, which slightly slims this pipeline's install.

## Audit of other pipelines

Checked the rest while I was here — everything else is already up to date:

- `apple/` — pins `appleconnector>=0.4.1` (latest) ✅
- `podigee/` — pins `podigeeconnector>=0.4.1` (latest, just published from the [uv migration](https://github.com/openpodcast/podigee-connector/releases/tag/v0.4.1)) ✅
- `anchor/` — pins `spotifygraphqlconnector==0.5.2` (latest) ✅
- `spotify/` — this PR ⬅️