### PR TITLE
podigee: skip empty payloads and harden transforms against null fields

### DIFF
--- a/podigee/job/transforms.py
+++ b/podigee/job/transforms.py
@@ -9,12 +9,12 @@ def transform_podigee_podcast_overview(overview_data):
     """
     Transform Podigee podcast overview data to OpenPodcast format.
     """
-    if not overview_data or "meta" not in overview_data:
+    if not overview_data or not overview_data.get("meta"):
         return {"metrics": []}
 
     # Extract common metadata
-    start_date = extract_date_str_from_iso(overview_data["meta"]["from"])
-    end_date = extract_date_str_from_iso(overview_data["meta"]["to"])
+    start_date = extract_date_str_from_iso(overview_data["meta"].get("from"))
+    end_date = extract_date_str_from_iso(overview_data["meta"].get("to"))
 
     metrics = []
 
@@ -57,15 +57,17 @@ def transform_podigee_analytics_to_metrics(analytics_data, store_downloads_only=
     Transform Podigee analytics data to OpenPodcast metrics format.
     Expected format: {"metrics": [{"start": "date", "end": "date", "dimension": "string", "subdimension": "string", "value": number}]}
     """
-    if not analytics_data or "objects" not in analytics_data:
+    if not analytics_data or not analytics_data.get("objects"):
         return {"metrics": []}
 
-    aggregation_granularity = analytics_data.get("meta", {}).get(
+    aggregation_granularity = (analytics_data.get("meta") or {}).get(
         "aggregation_granularity", "day"
     )
     metrics = []
 
     for day_data in analytics_data["objects"]:
+        if not day_data:
+            continue
         date = extract_date_str_from_iso(day_data.get("downloaded_on", ""))
         if not date:
             continue

--- a/podigee/job/worker.py
+++ b/podigee/job/worker.py
@@ -23,16 +23,28 @@ def fetch(openpodcast: OpenPodcastConnector, params: FetchParams) -> None:
     """
     try:
         data = params.podigee_call()
-        if data:
-            logger.info(f"Sending {params.openpodcast_endpoint} to Open Podcast")
-            response = openpodcast.post(
-                params.openpodcast_endpoint,
-                params.meta,
-                data,
-                params.start_date,
-                params.end_date,
+
+        # Treat None, empty containers, and {"metrics": []} as "no data".
+        metrics = data.get("metrics") if isinstance(data, dict) else None
+        is_empty = not data or metrics == []
+
+        if is_empty:
+            logger.warning(
+                f"Podigee returned no data for `{params.openpodcast_endpoint}` "
+                f"[{params.start_date} - {params.end_date}] "
+                f"meta={params.meta} data={data!r}; skipping post."
             )
-            logger.debug(f"Response: {response.status_code} - {response.text}")
+            return
+
+        logger.info(f"Sending {params.openpodcast_endpoint} to Open Podcast")
+        response = openpodcast.post(
+            params.openpodcast_endpoint,
+            params.meta,
+            data,
+            params.start_date,
+            params.end_date,
+        )
+        logger.debug(f"Response: {response.status_code} - {response.text}")
     except requests.exceptions.HTTPError as e:
         logger.error(e)
         return


### PR DESCRIPTION
## Problem

The hoster metrics check flagged `no data in hosterPodcastMetrics on 2026-05-10` for a Podigee-hosted account. Tracing the pipeline revealed two issues that can mask or cause this:

1. When Podigee returns nothing useful (e.g. `None`, `{}`, or a response with empty/missing `objects`), the transforms produce `{"metrics": []}`. The worker's `if data:` guard treats this as truthy and POSTs an empty payload to the Open Podcast API, which downstream sees as 'no data'.
2. If Podigee returns a JSON `null` for `objects` or `meta` (rather than omitting the key), the existing `"objects" not in analytics_data` check passes but the subsequent iteration raises `TypeError`. That's not a `requests.HTTPError`, so it bubbles out of the worker thread silently.

## Changes

- `podigee/job/worker.py`: detect empty payloads (`None`, `{}`, `{"metrics": []}`) and emit a `logger.warning` containing the received data and the request meta, instead of posting. This both fixes the silent-empty-post and gives us visibility into the actual Podigee response next time the alert fires.
- `podigee/job/transforms.py`: handle `meta=None` and `objects=None` defensively so the worker thread can no longer die silently on a null field.

## Verification

Existing tests pass:

```
$ uv run pytest job/test_transform.py -q
........  8 passed
```

Zero-traffic days from Podigee (e.g. `{"downloads": {"complete": 0}, "formats": {}, ...}`) still produce a non-empty metrics list and are POSTed as before — the new check only suppresses genuinely empty payloads.